### PR TITLE
feat: Improve /recv endpoint responses and add latest import APIs

### DIFF
--- a/import_tags.sh
+++ b/import_tags.sh
@@ -58,35 +58,35 @@ if [ $? -ne 0 ]; then
 fi
 
 # Parse response using jq
-SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+STATUS=$(echo "$RESPONSE" | jq -r '.status')
 IMPORT_ID=$(echo "$RESPONSE" | jq -r '.import_id')
 ITEMS_COUNT=$(echo "$RESPONSE" | jq -r '.items_count')
-MESSAGE=$(echo "$RESPONSE" | jq -r '.message')
-STATUS=$(echo "$RESPONSE" | jq -r '.status')
 PROCESSED=$(echo "$RESPONSE" | jq -r '.processed_locations')
+IMPORTED_AT=$(echo "$RESPONSE" | jq -r '.imported_at')
+ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error')
 
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${GREEN}📥 Response:${NC}"
 echo ""
 
-if [ "$SUCCESS" = "true" ]; then
+if [ "$STATUS" = "ok" ]; then
     echo -e "${GREEN}✅ Import Successful!${NC}"
     echo ""
     echo -e "${YELLOW}📋 Details:${NC}"
     echo -e "  • Import ID: ${GREEN}$IMPORT_ID${NC}"
     echo -e "  • Total Items: ${GREEN}$ITEMS_COUNT${NC}"
-    echo -e "  • Status: ${GREEN}$STATUS${NC}"
     echo -e "  • Processed Locations: ${GREEN}$PROCESSED${NC}"
-    echo -e "  • Message: $MESSAGE"
-elif [ "$SUCCESS" = "false" ]; then
-    echo -e "${YELLOW}⚠️  Import Skipped${NC}"
+elif [ "$STATUS" = "duplicated" ]; then
+    echo -e "${YELLOW}⚠️  Import Duplicated${NC}"
     echo ""
     echo -e "${YELLOW}📋 Details:${NC}"
-    echo -e "  • Message: $MESSAGE"
-    if [ ! -z "$IMPORT_ID" ] && [ "$IMPORT_ID" != "null" ]; then
-        echo -e "  • Existing Import ID: ${YELLOW}$IMPORT_ID${NC}"
-        echo -e "  • Status: ${YELLOW}$STATUS${NC}"
-    fi
+    echo -e "  • Existing Import ID: ${YELLOW}$IMPORT_ID${NC}"
+    echo -e "  • Originally Imported: ${YELLOW}$IMPORTED_AT${NC}"
+elif [ "$STATUS" = "error" ]; then
+    echo -e "${RED}❌ Import Error${NC}"
+    echo ""
+    echo -e "${RED}📋 Details:${NC}"
+    echo -e "  • Error: ${RED}$ERROR_MSG${NC}"
 else
     echo -e "${RED}❌ Unexpected Response:${NC}"
     echo "$RESPONSE" | jq '.'

--- a/pb_hooks/data_import_handler.pb.js
+++ b/pb_hooks/data_import_handler.pb.js
@@ -121,8 +121,8 @@ routerAdd("POST", "/recv", (e) => {
         if (err.message && !err.message.includes("no rows")) {
           console.error("[Data Import] Database error:", err.message)
           return e.json(500, {
-            success: false,
-            error: "Database error while checking for duplicates"
+            status: "error",
+            error: "Database error"
           })
         }
       }
@@ -131,11 +131,9 @@ routerAdd("POST", "/recv", (e) => {
         const existingId = existingRecord.get("id")
         console.log("[Data Import] Duplicate found, ID:", existingId)
         return e.json(200, {
-          success: false,
-          message: "Data already imported",
+          status: "duplicated",
           import_id: existingId,
-          imported_at: existingRecord.get("import_date"),
-          status: existingRecord.get("status")
+          imported_at: existingRecord.get("import_date")
         })
       }
       
@@ -172,21 +170,17 @@ routerAdd("POST", "/recv", (e) => {
         }
         
         return e.json(200, {
-          success: true,
+          status: "ok",
           import_id: recordId,
           items_count: itemCount,
-          status: record.get("status"),
-          processed_locations: processedCount,
-          message: processedCount > 0 
-            ? `Import successful, ${processedCount} new locations added`
-            : "Import successful, data stored for processing"
+          processed_locations: processedCount
         })
         
       } catch (saveError) {
         console.error("[Data Import] Failed to save:", saveError.message)
         return e.json(500, {
-          success: false,
-          error: "Failed to save import: " + saveError.message
+          status: "error",
+          error: saveError.message
         })
       }
       

--- a/pb_hooks/latest_import_api.pb.js
+++ b/pb_hooks/latest_import_api.pb.js
@@ -1,0 +1,169 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// API endpoint to get the latest data import
+routerAdd("GET", "/api/latest-import", (e) => {
+    console.log("[Latest Import API] Request received")
+    
+    try {
+        // Find the most recent data_imports record
+        const records = $app.findRecordsByFilter(
+            "data_imports",
+            "", // no filter - get all
+            "-import_date", // sort by import_date descending
+            1, // limit to 1 record
+            0  // offset 0
+        )
+        
+        if (!records || records.length === 0) {
+            console.log("[Latest Import API] No imports found")
+            return e.json(404, {
+                success: false,
+                message: "No data imports found"
+            })
+        }
+        
+        const latestImport = records[0]
+        console.log("[Latest Import API] Found latest import:", latestImport.get("id"))
+        
+        // Get the JSON content
+        let jsonContentRaw = latestImport.get("json_content")
+        let jsonContent
+        
+        // Convert to string first if needed (same as in hooks)
+        let jsonStr = ""
+        if (typeof jsonContentRaw === 'object' && jsonContentRaw.length) {
+            // It's a byte array or character array - convert to string
+            console.log("[Latest Import API] Converting byte array to string...")
+            for (let i = 0; i < jsonContentRaw.length; i++) {
+                jsonStr += String.fromCharCode(jsonContentRaw[i])
+            }
+        } else if (typeof jsonContentRaw === 'string') {
+            jsonStr = jsonContentRaw
+        } else {
+            console.log("[Latest Import API] Unexpected data type:", typeof jsonContentRaw)
+            return e.json(500, {
+                success: false,
+                message: "Unexpected data format"
+            })
+        }
+        
+        // Now parse the JSON string
+        try {
+            jsonContent = JSON.parse(jsonStr)
+            console.log("[Latest Import API] Parsed JSON, type:", typeof jsonContent, 
+                "Is Array?:", Array.isArray(jsonContent))
+        } catch (err) {
+            console.error("[Latest Import API] Failed to parse JSON:", err.message)
+            return e.json(500, {
+                success: false,
+                message: "Failed to parse import data"
+            })
+        }
+        
+        // Calculate summary statistics
+        let summary = {
+            total_items: 0,
+            valid_tags: 0,
+            tags_with_location: 0,
+            tag_list: []
+        }
+        
+        if (Array.isArray(jsonContent)) {
+            summary.total_items = jsonContent.length
+            
+            jsonContent.forEach(item => {
+                if (item.name && item.name.match(/^Tag \d+$/)) {
+                    summary.valid_tags++
+                    summary.tag_list.push(item.name)
+                    
+                    if (item.location && item.location.latitude && item.location.longitude) {
+                        summary.tags_with_location++
+                    }
+                }
+            })
+            
+            // Sort tag list numerically
+            summary.tag_list.sort((a, b) => {
+                const numA = parseInt(a.replace('Tag ', ''))
+                const numB = parseInt(b.replace('Tag ', ''))
+                return numA - numB
+            })
+        }
+        
+        // Return the latest import data with summary
+        return e.json(200, {
+            success: true,
+            import: {
+                id: latestImport.get("id"),
+                import_date: latestImport.get("import_date"),
+                source: latestImport.get("source"),
+                status: latestImport.get("status"),
+                content_hash: latestImport.get("content_hash"),
+                item_count: latestImport.get("item_count"),
+                created: latestImport.get("created"),
+                updated: latestImport.get("updated")
+            },
+            summary: summary,
+            data: jsonContent
+        })
+        
+    } catch (error) {
+        console.error("[Latest Import API] Error:", error.message)
+        return e.json(500, {
+            success: false,
+            error: error.message
+        })
+    }
+})
+
+// API endpoint to get just the latest import metadata (without full JSON data)
+routerAdd("GET", "/api/latest-import-info", (e) => {
+    console.log("[Latest Import Info API] Request received")
+    
+    try {
+        // Find the most recent data_imports record
+        const records = $app.findRecordsByFilter(
+            "data_imports",
+            "", // no filter - get all
+            "-import_date", // sort by import_date descending
+            1, // limit to 1 record
+            0  // offset 0
+        )
+        
+        if (!records || records.length === 0) {
+            console.log("[Latest Import Info API] No imports found")
+            return e.json(404, {
+                success: false,
+                message: "No data imports found"
+            })
+        }
+        
+        const latestImport = records[0]
+        console.log("[Latest Import Info API] Found latest import:", latestImport.get("id"))
+        
+        // Return just the metadata
+        return e.json(200, {
+            success: true,
+            import: {
+                id: latestImport.get("id"),
+                import_date: latestImport.get("import_date"),
+                source: latestImport.get("source"),
+                status: latestImport.get("status"),
+                content_hash: latestImport.get("content_hash"),
+                item_count: latestImport.get("item_count"),
+                created: latestImport.get("created"),
+                updated: latestImport.get("updated")
+            }
+        })
+        
+    } catch (error) {
+        console.error("[Latest Import Info API] Error:", error.message)
+        return e.json(500, {
+            success: false,
+            error: error.message
+        })
+    }
+})
+
+console.log("[Latest Import API] Registered GET /api/latest-import endpoint")
+console.log("[Latest Import API] Registered GET /api/latest-import-info endpoint")

--- a/pb_hooks/latest_import_data_api.pb.js
+++ b/pb_hooks/latest_import_data_api.pb.js
@@ -1,0 +1,72 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// API endpoint to get just the data array from latest import (for DuckDB compatibility)
+routerAdd("GET", "/api/latest-import-data", (e) => {
+    console.log("[Latest Import Data API] Request received")
+    
+    try {
+        // Find the most recent data_imports record
+        const records = $app.findRecordsByFilter(
+            "data_imports",
+            "", // no filter - get all
+            "-import_date", // sort by import_date descending
+            1, // limit to 1 record
+            0  // offset 0
+        )
+        
+        if (!records || records.length === 0) {
+            console.log("[Latest Import Data API] No imports found")
+            // Return empty array for DuckDB compatibility
+            return e.json(200, [])
+        }
+        
+        const latestImport = records[0]
+        console.log("[Latest Import Data API] Found latest import:", latestImport.get("id"))
+        
+        // Get the JSON content
+        let jsonContentRaw = latestImport.get("json_content")
+        let jsonContent
+        
+        // Convert to string first if needed (same as in hooks)
+        let jsonStr = ""
+        if (typeof jsonContentRaw === 'object' && jsonContentRaw.length) {
+            // It's a byte array or character array - convert to string
+            console.log("[Latest Import Data API] Converting byte array to string...")
+            for (let i = 0; i < jsonContentRaw.length; i++) {
+                jsonStr += String.fromCharCode(jsonContentRaw[i])
+            }
+        } else if (typeof jsonContentRaw === 'string') {
+            jsonStr = jsonContentRaw
+        } else {
+            console.log("[Latest Import Data API] Unexpected data type:", typeof jsonContentRaw)
+            // Return empty array for DuckDB compatibility
+            return e.json(200, [])
+        }
+        
+        // Now parse the JSON string
+        try {
+            jsonContent = JSON.parse(jsonStr)
+            console.log("[Latest Import Data API] Parsed JSON, type:", typeof jsonContent, 
+                "Is Array?:", Array.isArray(jsonContent))
+        } catch (err) {
+            console.error("[Latest Import Data API] Failed to parse JSON:", err.message)
+            // Return empty array for DuckDB compatibility
+            return e.json(200, [])
+        }
+        
+        // Return just the array data
+        if (Array.isArray(jsonContent)) {
+            return e.json(200, jsonContent)
+        } else {
+            // If it's a single object, wrap it in an array
+            return e.json(200, [jsonContent])
+        }
+        
+    } catch (error) {
+        console.error("[Latest Import Data API] Error:", error.message)
+        // Return empty array for DuckDB compatibility
+        return e.json(200, [])
+    }
+})
+
+console.log("[Latest Import Data API] Registered GET /api/latest-import-data endpoint")


### PR DESCRIPTION
## Summary
- Simplified /recv endpoint responses with clear status indicators
- Added new API endpoints for retrieving latest import data
- Updated import script to handle new response format

## Changes
### 1. Improved /recv endpoint responses
- Added `status` field with values: `"ok"`, `"duplicated"`, `"error"`
- Removed confusing `success: false` for duplicates
- Simplified response structure

### 2. New API endpoints
- **`GET /api/latest-import`** - Full data with summary statistics
- **`GET /api/latest-import-data`** - Just the array (DuckDB compatible)
- **`GET /api/latest-import-info`** - Metadata only (lightweight)

### 3. Updated import_tags.sh
- Now checks `status` field instead of `success`
- Better visual feedback for each status type

## Test Results
✅ **New import:**
```json
{
  "status": "ok",
  "import_id": "4tffy6xybl47bje",
  "items_count": 1,
  "processed_locations": 0
}
```

✅ **Duplicate import:**
```json
{
  "status": "duplicated",
  "import_id": "4tffy6xybl47bje",
  "imported_at": "2025-08-29 19:55:47.238Z"
}
```

✅ **DuckDB compatible endpoint:**
```sql
-- Works with direct array response
SELECT name, location.latitude, location.longitude
FROM read_json_auto('http://localhost:8090/api/latest-import-data')
WHERE name LIKE 'Tag %'
```

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)