### PR TITLE
feat: Server-side content hashing for /recv (canonical MD5)

### DIFF
--- a/.claude/issues/nnn_server_hash_recv.md
+++ b/.claude/issues/nnn_server_hash_recv.md
@@ -1,0 +1,46 @@
+# Plan: Server-side content hashing for /recv (data_imports)
+
+## Overview
+Refactor the POST /recv handler to compute a canonical MD5 hash of the request content on the server using PocketBase’s $security API, and use it for deduplication and storage (content_hash). This removes trust in client-provided md5 while maintaining backward-compatible duplicate detection.
+
+## Current Behavior
+- Handler uses `body.md5` for dedup and stores it as `content_hash`.
+- Accepts `body.content` (parsed JSON) from `e.requestInfo()`.
+
+## Proposed Solution
+- Compute `computed_hash = $security.md5(stableStringify(body.content))` server-side.
+- Deduplicate by `content_hash = computed_hash`.
+- Backward-compat check: if no match, and client provided a 32-hex md5, also check `content_hash = body.md5` (transition safety).
+- Store `content_hash = computed_hash`. Keep `status=pending`, `item_count` as today.
+- Response includes `computed_hash` (and `provided_hash` if sent) for transparency.
+
+## Canonicalization
+Implement `stableStringify(v)` that deterministically stringifies JSON:
+- Primitives: `JSON.stringify(v)`.
+- Arrays: `[` + join of stableStringify(element) + `]`.
+- Objects: sort keys (ASCII), stringify each value recursively, and build `{k:v}` in key order.
+
+## Implementation Steps
+1) Update `pb_hooks/100_data_import_handler.pb.js`:
+   - Add `stableStringify` helper inside the route handler (or load via utils if preferred).
+   - Compute `computed_hash` and replace all uses of `body.md5` with `computed_hash` for creation and duplicate check.
+   - Add fallback duplicate check on `body.md5` (32-hex) only if needed.
+   - Return `computed_hash` in success/duplicate responses and log both hashes.
+2) No schema changes required (reuse `content_hash`).
+3) Validate with existing script `import_tags.sh` (works unchanged; server ignores provided md5 for storage).
+
+## Risks & Mitigations
+- Large JSON cost: Items.data scale is acceptable; consider chunking if needed later.
+- Client/server mismatch: Expected; dedup happens server-side; include both hashes in response for visibility.
+- Canonicalization correctness: Unit-test stringify on representative nested objects/arrays.
+
+## Acceptance Criteria
+- New import with same content twice → second returns `duplicated`.
+- Legacy import created with client md5 → re-posting same content returns `duplicated` (fallback check).
+- New records store `content_hash = computed_hash`.
+- Response includes `computed_hash` and optionally `provided_hash`.
+
+## Follow-ups (later PRs)
+- Add per-import processed/duplicate/error counters.
+- Standardize location_hash across pipeline and DuckDB.
+- Promote pet API from archive.

--- a/pb_hooks/100_data_import_handler.pb.js
+++ b/pb_hooks/100_data_import_handler.pb.js
@@ -17,20 +17,37 @@ routerAdd("POST", "/recv", (e) => {
 
   // Validation Functions
   function validateImportRequest(body) {
-    if (!body?.md5 || !body?.content) {
-      return { valid: false, error: "Missing required fields: md5 and content" }
+    if (!body?.content) {
+      return { valid: false, error: "Missing required field: content" }
     }
-
-    // if (!isValidMd5Hash(body.md5)) {
-    //   return { valid: false, error: "Invalid MD5 hash format (must be 32 hex characters)" }
-    // }
-
     return { valid: true }
   }
 
-  // function isValidMd5Hash(hash) {
-  //   return typeof hash === 'string' && /^[a-f0-9]{32}$/i.test(hash)
-  // }
+  function isValidMd5Hash(hash) {
+    return typeof hash === 'string' && /^[a-f0-9]{32}$/i.test(hash)
+  }
+
+  // Deterministic JSON stringifier to ensure stable hashing
+  function stableStringify(value) {
+    const type = typeof value
+    if (value === null || type === 'number' || type === 'boolean' || type === 'string') {
+      return JSON.stringify(value)
+    }
+    if (Array.isArray(value)) {
+      const parts = value.map(v => stableStringify(v))
+      return `[${parts.join(',')}]`
+    }
+    if (type === 'object') {
+      const keys = Object.keys(value).sort()
+      const parts = []
+      for (const k of keys) {
+        parts.push(`${JSON.stringify(k)}:${stableStringify(value[k])}`)
+      }
+      return `{${parts.join(',')}}`
+    }
+    // Fallback for unsupported types
+    return JSON.stringify(String(value))
+  }
 
   // Business Logic Functions
   function checkForDuplicate($app, hash) {
@@ -49,11 +66,11 @@ routerAdd("POST", "/recv", (e) => {
     }
   }
 
-  function createImportRecord($app, requestData) {
+  function createImportRecord($app, requestData, computedHash) {
     const collection = $app.findCollectionByNameOrId(CONFIG.COLLECTIONS.DATA_IMPORTS)
     const record = new Record(collection, {
       import_date: new Date().toISOString(),
-      content_hash: requestData.md5,
+      content_hash: computedHash,
       json_content: requestData.content,
       source: requestData.source || CONFIG.SOURCES.API,
       status: CONFIG.STATUSES.PENDING,
@@ -110,23 +127,38 @@ routerAdd("POST", "/recv", (e) => {
     }
 
     console.log("[Data Import] Valid import format detected")
-    console.log("[Data Import] MD5 hash:", body.md5)
     console.log("[Data Import] Content type:", ImportUtils.getContentType(body.content))
 
-    // 2. Check for duplicates
-    const duplicate = checkForDuplicate($app, body.md5)
+    // 2. Compute server-side hash from canonical JSON
+    const computedHash = $security.md5(stableStringify(body.content))
+    const providedHash = body.md5 && isValidMd5Hash(body.md5) ? body.md5 : null
+    console.log("[Data Import] Provided hash:", providedHash || "<none>")
+    console.log("[Data Import] Computed hash:", computedHash)
+
+    // 3. Check for duplicates using computed hash first
+    let duplicate = checkForDuplicate($app, computedHash)
+    // Backward-compat: also check provided hash if computed not found
+    if (!duplicate && providedHash) {
+      duplicate = checkForDuplicate($app, providedHash)
+    }
     if (duplicate) {
       console.log("[Data Import] Duplicate found, ID:", duplicate.get("id"))
-      return e.json(200, buildDuplicateResponse(duplicate))
+      const resp = buildDuplicateResponse(duplicate)
+      resp.computed_hash = computedHash
+      if (providedHash) resp.provided_hash = providedHash
+      return e.json(200, resp)
     }
 
-    // 3. Create new import record
+    // 4. Create new import record
     console.log("[Data Import] Creating new import record...")
-    const record = createImportRecord($app, body)
+    const record = createImportRecord($app, body, computedHash)
     const itemCount = getItemCount(body.content)
 
-    console.log("[Data Import] ✅ Import saved successfully, Hash:", body.md5)
-    return e.json(200, buildSuccessResponse(record, itemCount))
+    console.log("[Data Import] ✅ Import saved successfully with computed hash:", computedHash)
+    const resp = buildSuccessResponse(record, itemCount)
+    resp.computed_hash = computedHash
+    if (providedHash) resp.provided_hash = providedHash
+    return e.json(200, resp)
 
   } catch (error) {
     console.error("[Data Import] Unexpected error:", error.message)


### PR DESCRIPTION
Implements server-side hashing for data imports to enforce deduplication based on a canonical, deterministic hash.\n\n- Compute \n- Deduplicate on computed hash; fallback to provided md5 for legacy records\n- Store computed hash in ; responses include  and optional \n- Validation now requires only \n\nPlan: #56\n\nThis change removes trust in client-provided hashes while keeping compatibility with older imports. No schema changes.