### PR TITLE
docs+compat: Runbook/Hashing + processed_locations=0 + reset helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Pocket Pet Tracker — PocketBase (Go) + Runbook
+
+This repo ingests Apple Find My “Items” JSON and stores tag location history in PocketBase. A native Go app under `pbgo/` exposes `POST /recv` and a model lifecycle hook processes imports into `pet_locations` with dedupe and status.
+
+## Quick Start
+
+- Prereqs: Go 1.21+, jq, sqlite3, tmux (optional)
+- Start server (port 9999):
+  - `cd pbgo && go run ./cmd/pbgo serve --http 0.0.0.0:9999 --dir ../pb_data`
+- Import current `Items.data`:
+  - `bash scripts/recv_post.sh 9999`
+- Verify counts:
+  - `sqlite3 pb_data/data.db 'SELECT COUNT(*) FROM data_imports; SELECT COUNT(*) FROM pet_locations;'`
+
+## Runbook
+
+- Reset + run + import (manual):
+  - Stop any server on 9999: `lsof -nP -iTCP:9999 -sTCP:LISTEN -t | xargs -r kill`
+  - `rm -rf pb_data && mkdir pb_data`
+  - Start: `cd pbgo && go run ./cmd/pbgo serve --http 0.0.0.0:9999 --dir ../pb_data`
+  - Create superuser: `cd pbgo && go run ./cmd/pbgo superuser upsert nat@catlabs.me changeme --dir ../pb_data`
+  - Import: `cd .. && bash scripts/recv_post.sh 9999`
+  - Counts: `sqlite3 pb_data/data.db 'SELECT id,status,item_count FROM data_imports ORDER BY import_date DESC LIMIT 1; SELECT COUNT(*) FROM pet_locations;'`
+
+- With tmux helper (split panes):
+  - `TMUX_SESSION=pbgo-dev PBGO_PORT=9999 bash scripts/pbgo_tmux.sh start`
+  - `TMUX_SESSION=pbgo-dev bash scripts/pbgo_tmux.sh run 'bash scripts/recv_post.sh 9999'`
+  - `TMUX_SESSION=pbgo-dev bash scripts/pbgo_tmux.sh status`
+
+## Hashing Spec
+
+- `content_hash`: `md5(stableStringify(content))`
+  - stableStringify = deterministic JSON (keys sorted, arrays preserved)
+- `location_hash`: `md5(pet_name + latitude + longitude + accuracy)`
+  - Timestamp excluded to align with DuckDB exports
+
+## Compatibility
+
+- `/recv` responds with:
+  - On new import: `{ status: "ok", import_id, items_count, processed_locations: 0 }`
+  - On duplicate: `{ status: "duplicated", import_id, imported_at, processed_locations: 0 }`
+  - Note: processing is asynchronous via a model lifecycle hook; counts show 0 at ingest time by design.
+
+## import_tags.sh
+
+- Now supports overrides:
+  - `API_URL="http://localhost:9999/recv" ./import_tags.sh`
+  - `./import_tags.sh --url http://localhost:9999/recv --file /path/to/Items.data`
+- Default endpoint remains `http://localhost:8090/recv` unless overridden.
+
+## Timezone
+
+- Primary display is GMT+7 (Bangkok). UTC omitted for brevity in retrospectives.
+
+## Notes
+
+- JSVM is used only for migrations; JS hooks are disabled in the Go path.
+- The model lifecycle hook (`OnRecordAfterCreateSuccess("data_imports")`) performs JSON decode, dedupe, insert, and status derivation.
+

--- a/pbgo/internal/handlers/recv.go
+++ b/pbgo/internal/handlers/recv.go
@@ -39,6 +39,8 @@ func BindRecv(pb *pocketbase.PocketBase) {
                     "status":      "duplicated",
                     "import_id":   duplicate.Id,
                     "imported_at": duplicate.GetString("import_date"),
+                    // Compatibility: processing happens asynchronously in the hook
+                    "processed_locations": 0,
                 })
             }
             if err != nil && err != sql.ErrNoRows {
@@ -73,9 +75,10 @@ func BindRecv(pb *pocketbase.PocketBase) {
             }
 
             return e.JSON(http.StatusOK, map[string]any{
-                "status":      "ok",
-                "import_id":   rec.Id,
-                "items_count": itemCount,
+                "status":               "ok",
+                "import_id":            rec.Id,
+                "items_count":          itemCount,
+                "processed_locations":  0,
             })
         })
         return e.Next()

--- a/scripts/reset_and_import.sh
+++ b/scripts/reset_and_import.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reset DB, start server (tmux), create superuser, import Items.data, print counts.
+# Usage: PORT=9999 TMUX_SESSION=pbgo-dev ./scripts/reset_and_import.sh
+
+PORT=${PORT:-9999}
+SESSION=${TMUX_SESSION:-pbgo-dev}
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+need jq
+need sqlite3
+need tmux
+need lsof
+need go
+
+cd "$ROOT_DIR"
+
+echo "Killing any listeners on :$PORT..."
+PIDS=$(lsof -nP -iTCP:$PORT -sTCP:LISTEN -t || true)
+if [ -n "$PIDS" ]; then kill $PIDS || true; sleep 1; fi
+LEFT=$(lsof -nP -iTCP:$PORT -sTCP:LISTEN -t || true)
+if [ -n "$LEFT" ]; then kill -9 $LEFT || true; sleep 1; fi
+
+echo "Resetting pb_data..."
+rm -rf pb_data && mkdir -p pb_data
+
+echo "Starting server in tmux ($SESSION)..."
+TMUX_SESSION="$SESSION" PBGO_PORT="$PORT" bash scripts/pbgo_tmux.sh start
+sleep 6
+
+echo "Creating superuser..."
+tmux send-keys -t "$SESSION:pbgo.1" 'cd pbgo && go run ./cmd/pbgo superuser upsert nat@catlabs.me changeme --dir ../pb_data' C-m
+sleep 2
+
+echo "Posting import..."
+tmux send-keys -t "$SESSION:pbgo.1" "cd .. && bash scripts/recv_post.sh $PORT" C-m
+sleep 3
+
+echo "Printing counts..."
+sqlite3 pb_data/data.db 'SELECT id,status,item_count FROM data_imports ORDER BY import_date DESC LIMIT 1; SELECT COUNT(*) FROM pet_locations;'
+
+echo "Done."
+


### PR DESCRIPTION
This PR improves dev ergonomics and client compatibility.\n\n- README: Runbook (start, import, verify), tmux usage, Hashing Spec, timezone note\n- /recv: adds processed_locations: 0 to new/duplicate responses for compatibility\n- scripts: reset_and_import.sh for one-step demo (tmux-based)\n\nVerification: used tmux capture to reset DB, start server, import, and confirm counts (imports=1, pet_locations=28).